### PR TITLE
Fix collision with sprite implemented

### DIFF
--- a/bci-game/Assets/Character.cs
+++ b/bci-game/Assets/Character.cs
@@ -87,10 +87,12 @@ public class Character : MonoBehaviour
     void OnTriggerEnter(Collider other) {
 
         //check collisions by examining each corner of character and other object
-        int collisionDirection = CheckCollisionDirection(transform, other.gameObject.transform); //0 = top, 1 = bottom, 2 = right, 3 = left;
-
+        BoxCollider otherBox = other.gameObject.GetComponent<BoxCollider>();
+        int collisionDirection = CheckCollisionDirection(GetComponent<BoxCollider>(), otherBox); 
+        //0 = top, 1 = bottom, 2 = right, 3 = left;
+        //Debug.Log(collisionDirection);
         //contact above, below, left, and right
-        movementBlocked[collisionDirection] += 1;
+        if (collisionDirection >= 0) movementBlocked[collisionDirection] += 1;
 
         //landing on ground
         if (collisionDirection == 1) {
@@ -103,7 +105,7 @@ public class Character : MonoBehaviour
             jumpTime = 0;
         }
 
-        RemoveOverlap(collisionDirection, transform, other.gameObject.transform);
+        RemoveOverlap(collisionDirection, GetComponent<BoxCollider>(), otherBox);
 
         //store collision info for exit function
         pastCollisions.Add(other.name, collisionDirection);
@@ -123,21 +125,32 @@ public class Character : MonoBehaviour
         }
     }
 
-    private int CheckCollisionDirection(Transform self, Transform other) {
+    private int CheckCollisionDirection(BoxCollider self, BoxCollider other) {
         //0 = top, 1 = bottom, 2 = right, 3 = left
 
+        float xpos = self.transform.position.x;
+        float ypos = self.transform.position.y;
+        float xsize = self.size.x * self.transform.localScale.x / 2;
+        float ysize = self.size.y * self.transform.localScale.y / 2;
+        
         //corner order: top right, top left, bottom right, bottom left
         Vector3[] selfCorners = {
-            new Vector3(self.transform.position.x + self.transform.localScale.x / 2, self.transform.position.y + self.transform.localScale.y / 2, 0),
-            new Vector3(self.transform.position.x - self.transform.localScale.x / 2, self.transform.position.y + self.transform.localScale.y / 2, 0),
-            new Vector3(self.transform.position.x + self.transform.localScale.x / 2, self.transform.position.y - self.transform.localScale.y / 2, 0),
-            new Vector3(self.transform.position.x - self.transform.localScale.x / 2, self.transform.position.y - self.transform.localScale.y / 2, 0)
+            new Vector3(xpos + xsize, ypos + ysize, 0),
+            new Vector3(xpos - xsize, ypos + ysize, 0),
+            new Vector3(xpos + xsize, ypos - ysize, 0),
+            new Vector3(xpos - xsize, ypos - ysize, 0)
         };
+
+        xpos = other.transform.position.x;
+        ypos = other.transform.position.y;
+        xsize = other.size.x * other.transform.localScale.x / 2;
+        ysize = other.size.y * other.transform.localScale.y / 2;
+
         Vector3[] otherCorners = {
-            new Vector3(other.transform.position.x + other.transform.localScale.x / 2, other.transform.position.y + other.transform.localScale.y / 2, 0),
-            new Vector3(other.transform.position.x - other.transform.localScale.x / 2, other.transform.position.y + other.transform.localScale.y / 2, 0),
-            new Vector3(other.transform.position.x + other.transform.localScale.x / 2, other.transform.position.y - other.transform.localScale.y / 2, 0),
-            new Vector3(other.transform.position.x - other.transform.localScale.x / 2, other.transform.position.y - other.transform.localScale.y / 2, 0)
+            new Vector3(xpos + xsize, ypos + ysize, 0),
+            new Vector3(xpos - xsize, ypos + ysize, 0),
+            new Vector3(xpos + xsize, ypos - ysize, 0),
+            new Vector3(xpos - xsize, ypos - ysize, 0)
         };
 
         //check if each corner is within other object
@@ -210,31 +223,36 @@ public class Character : MonoBehaviour
     }
 
     //move character so it does not overlap with platform
-    private void RemoveOverlap(int direction, Transform self, Transform other) {
+    private void RemoveOverlap(int direction, BoxCollider self, BoxCollider other) {
         float overlap;
         Vector3 change = new Vector3(0, 0, 0);
 
         //calculate overlap of objects
         //top
         if (direction == 0) {
-            overlap = self.transform.position.y + self.transform.localScale.y / 2 - (other.transform.position.y - other.transform.localScale.y / 2);
+            overlap = self.transform.position.y + self.transform.localScale.y * self.size.y / 2 - 
+                (other.transform.position.y - other.transform.localScale.y * other.size.y / 2);
             if (overlap > 0) change.y -= overlap;
         }
         //bottom
         if (direction == 1) {
-            overlap = other.transform.position.y + other.transform.localScale.y / 2 - (self.transform.position.y - self.transform.localScale.y / 2);
+            overlap = other.transform.position.y + other.transform.localScale.y * other.size.y / 2 - 
+                (self.transform.position.y - self.transform.localScale.y * self.size.y / 2);
             if (overlap > 0) change.y += overlap;
         }
         //right
         if (direction == 2) {
-            overlap = self.transform.position.x + self.transform.localScale.x / 2 - (other.transform.position.x - other.transform.localScale.x / 2);
+            overlap = self.transform.position.x + self.transform.localScale.x * self.size.x / 2 - 
+                (other.transform.position.x - other.transform.localScale.x * other.size.x / 2);
             if (overlap > 0) change.x -= overlap;
         }
         //left
         if (direction == 3) {
-            overlap = other.transform.position.x + other.transform.localScale.x / 2 - (self.transform.position.x - self.transform.localScale.x / 2);
+            overlap = other.transform.position.x + other.transform.localScale.x * other.size.x / 2 - 
+                (self.transform.position.x - self.transform.localScale.x * self.size.x / 2);
             if (overlap > 0) change.x += overlap;
         }
+        //Debug.Log(change);
 
         StartCoroutine(MoveCharacter(change));
     }

--- a/bci-game/Assets/Scenes/Animation Integration.unity
+++ b/bci-game/Assets/Scenes/Animation Integration.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028331, g: 0.2257133, b: 0.3069217, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -761,7 +761,7 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
+  m_SpriteSortPoint: 1
 --- !u!4 &1200090895
 Transform:
   m_ObjectHideFlags: 0
@@ -770,8 +770,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1200090893}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.2, z: 0}
-  m_LocalScale: {x: 1.0231917, y: 1, z: 1}
+  m_LocalPosition: {x: 0, y: 1.15, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -822,7 +822,7 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
+  m_Size: {x: 2, y: 2, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!95 &1200090899
 Animator:

--- a/bci-game/Assets/Scenes/Animation.unity
+++ b/bci-game/Assets/Scenes/Animation.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028331, g: 0.2257133, b: 0.3069217, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -401,7 +401,7 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
+  m_SpriteSortPoint: 1
 --- !u!4 &1016797733
 Transform:
   m_ObjectHideFlags: 0

--- a/bci-game/Assets/Sprites/mc_jump3.png.meta
+++ b/bci-game/Assets/Sprites/mc_jump3.png.meta
@@ -45,7 +45,7 @@ TextureImporter:
   spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
-  alignment: 6
+  alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 32
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
@@ -108,7 +108,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 0
+    internalID: 1537655665
     vertices: []
     indices: 
     edges: []

--- a/bci-game/Assets/Sprites/mc_jumpleft.png.meta
+++ b/bci-game/Assets/Sprites/mc_jumpleft.png.meta
@@ -45,7 +45,7 @@ TextureImporter:
   spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
-  alignment: 7
+  alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 32
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
@@ -108,7 +108,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 0
+    internalID: 1537655665
     vertices: []
     indices: 
     edges: []

--- a/bci-game/Assets/Sprites/mc_left.png.meta
+++ b/bci-game/Assets/Sprites/mc_left.png.meta
@@ -112,8 +112,8 @@ TextureImporter:
         y: 384
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 6
+      pivot: {x: 0, y: 0}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -235,11 +235,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 320
-        y: 320
+        y: 319
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -259,8 +259,8 @@ TextureImporter:
         y: 256
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -280,8 +280,8 @@ TextureImporter:
         y: 256
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -301,8 +301,8 @@ TextureImporter:
         y: 256
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -322,8 +322,8 @@ TextureImporter:
         y: 256
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -343,8 +343,8 @@ TextureImporter:
         y: 256
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -364,8 +364,8 @@ TextureImporter:
         y: 192
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -385,8 +385,8 @@ TextureImporter:
         y: 192
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -406,8 +406,8 @@ TextureImporter:
         y: 192
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -427,8 +427,8 @@ TextureImporter:
         y: 192
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -448,8 +448,8 @@ TextureImporter:
         y: 192
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -469,8 +469,8 @@ TextureImporter:
         y: 192
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -595,8 +595,8 @@ TextureImporter:
         y: 64
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -616,8 +616,8 @@ TextureImporter:
         y: 64
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -637,8 +637,8 @@ TextureImporter:
         y: 64
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -658,8 +658,8 @@ TextureImporter:
         y: 64
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -679,8 +679,8 @@ TextureImporter:
         y: 64
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -700,8 +700,8 @@ TextureImporter:
         y: 64
         width: 64
         height: 64
-      alignment: 7
-      pivot: {x: 0.5, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/bci-game/Assets/Sprites/mc_right_spreadsheet.png.meta
+++ b/bci-game/Assets/Sprites/mc_right_spreadsheet.png.meta
@@ -112,8 +112,8 @@ TextureImporter:
         y: 384
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -238,8 +238,8 @@ TextureImporter:
         y: 320
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -259,8 +259,8 @@ TextureImporter:
         y: 256
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -280,8 +280,8 @@ TextureImporter:
         y: 256
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -301,8 +301,8 @@ TextureImporter:
         y: 256
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -322,8 +322,8 @@ TextureImporter:
         y: 256
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -343,8 +343,8 @@ TextureImporter:
         y: 256
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -364,8 +364,8 @@ TextureImporter:
         y: 192
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -381,12 +381,12 @@ TextureImporter:
       name: mc_right_spreadsheet_13
       rect:
         serializedVersion: 2
-        x: 64
+        x: 65
         y: 192
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -406,8 +406,8 @@ TextureImporter:
         y: 192
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -427,8 +427,8 @@ TextureImporter:
         y: 192
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -448,8 +448,8 @@ TextureImporter:
         y: 192
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -469,8 +469,8 @@ TextureImporter:
         y: 192
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -595,8 +595,8 @@ TextureImporter:
         y: 64
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -616,8 +616,8 @@ TextureImporter:
         y: 64
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -637,8 +637,8 @@ TextureImporter:
         y: 64
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -658,8 +658,8 @@ TextureImporter:
         y: 64
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -679,8 +679,8 @@ TextureImporter:
         y: 64
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -700,8 +700,8 @@ TextureImporter:
         y: 64
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -721,8 +721,8 @@ TextureImporter:
         y: 0
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -742,8 +742,8 @@ TextureImporter:
         y: 0
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -763,8 +763,8 @@ TextureImporter:
         y: 0
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -784,8 +784,8 @@ TextureImporter:
         y: 0
         width: 64
         height: 64
-      alignment: 6
-      pivot: {x: 0, y: 0}
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -815,7 +815,6 @@ TextureImporter:
       mc_right_spreadsheet_9: -1825305884
       mc_right_spreadsheet_5: -572166554
       mc_right_spreadsheet_29: -2020406410
-      mc_right_spreadsheet_28: -1652110144
       mc_right_spreadsheet_3: 198049391
       mc_right_spreadsheet_27: -492974149
       mc_right_spreadsheet_10: 1652475028
@@ -836,6 +835,7 @@ TextureImporter:
       mc_right_spreadsheet_14: 2135388346
       mc_right_spreadsheet_21: -1506010776
       mc_right_spreadsheet_20: -1962735734
+      mc_right_spreadsheet_28: -1652110144
       mc_right_spreadsheet_8: 1181327966
       mc_right_spreadsheet_2: -1490422249
       mc_right_spreadsheet_1: 514537187


### PR DESCRIPTION
## ClickUp ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://app.clickup.com/t/8684xc5ep)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Modified collision detection for objects with a sprite. Some sprites require the collider size to be changed, which was not properly reflected in collision detection. 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Open the Animation Integration scene
2. Move the character around and check collisions with the ground and platforms


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
Sprites should have pivot points set to the center, to ensure the box collider lines up with the sprite. As well, make sure to adjust the box collider size so that it matches the sprite


## Checklist
- [x] My PR name is descriptive
- [x] My commit messages are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [x] My code is organized, and commented and documented so that another dev can understand what I did
