### PR TITLE
Fix repeat jumps when holding jump button

### DIFF
--- a/bci-game/Assets/Player.cs
+++ b/bci-game/Assets/Player.cs
@@ -11,6 +11,7 @@ public class Player : Character
     public float attackCooldown = 1f; 
     public Transform frontCheck; 
     private bool canAttack = true; 
+    private bool pressedJump = false;
 
     public override float[] GetInput() {
         float hInput = Input.GetAxis("Horizontal");
@@ -24,6 +25,11 @@ public class Player : Character
                 PerformAttack();
             }
         }
+
+        // On jump, prevent more jumps until player lets go of button
+        if (vInput != 0 && !pressedJump) pressedJump = true;
+        else if (vInput != 0 && pressedJump) vInput = 0;
+        else if (vInput == 0 && pressedJump) pressedJump = false;
 
         return new float[] {hInput, vInput};
     }

--- a/bci-game/Assets/Scripts/Entity/Player/PlayerMovement.cs
+++ b/bci-game/Assets/Scripts/Entity/Player/PlayerMovement.cs
@@ -24,6 +24,8 @@ namespace Entity.Player
         private static readonly int Walking = Animator.StringToHash("IsWalking");
         private static readonly int Jumping = Animator.StringToHash("isJumping");
         private static readonly int Takeoff = Animator.StringToHash("takeoff");
+
+        public bool canJump = true;
         
         private void Start()
         {
@@ -58,8 +60,14 @@ namespace Entity.Player
 
         protected override bool Jump()
         {
+            // Check if current jump is valid
+            if (!canJump || Input.GetAxisRaw("Vertical") == 0) return false;
+
             if (!base.Jump()) // If base jump fails, return false
                 return false;
+            
+            // Set jump state
+            canJump = false;
 
             animator.SetTrigger(Takeoff);
             soundController.PlaySound(jumpSounds, jumpVolume);
@@ -68,6 +76,8 @@ namespace Entity.Player
         }
 
         protected override Vector2 GetMovementInput() {
+            // Check to reset Jump
+            if (!canJump) if (Input.GetAxisRaw("Vertical") == 0 && onGround) canJump = true;
             return new Vector2(Input.GetAxis("Horizontal"), Input.GetAxis("Vertical"));
         }
     }


### PR DESCRIPTION
## ClickUp ticket link
<!-- Please replace with your ticket's URL -->
[Fix Jumping Issues](https://app.clickup.com/t/8688q8wcd)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Fixed an issue where the player character would repeatedly jump when holding the jump button down. The player now only jumps once per button press.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Open the SFX demo scene
2. Hold down the jump button. The player should only jump once.
3. Press the jump button and wait until landing, then press jump again. The player should jump again.
4. Verify this also works when moving and with platforms.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
Overall, ensure that jumping feels responsive and natural.


## Checklist
- [x] My PR name is descriptive
- [x] My commit messages are descriptive. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [x] My code is organized, and commented and documented so that another dev can understand what I did
